### PR TITLE
Wildmatch implementation

### DIFF
--- a/MAB.DotIgnore.Test/IgnoreListTests.cs
+++ b/MAB.DotIgnore.Test/IgnoreListTests.cs
@@ -95,9 +95,9 @@ namespace MAB.DotIgnore.Tests
             var log = new List<string>();
             ignoreList.IsIgnored("sub1/README2.txt", true, log);
             Assert.IsTrue(log.Count == 3);
-            Assert.IsTrue(log[0] == "Ignored by *.txt > *.TXT > .*\\.TXT$");
-            Assert.IsTrue(log[1] == "Included by !sub1/*.txt > SUB1/*.TXT > SUB1/[^/]+\\.TXT$");
-            Assert.IsTrue(log[2] == "Ignored by sub1/README2.txt > SUB1/README2.TXT > SUB1/README2\\.TXT$");
+            Assert.IsTrue(log[0] == "Ignored by *.txt > *.txt");
+            Assert.IsTrue(log[1] == "Included by !sub1/*.txt > sub1/*.txt");
+            Assert.IsTrue(log[2] == "Ignored by sub1/README2.txt > sub1/README2.txt");
         }
 
         [Test]
@@ -126,7 +126,7 @@ namespace MAB.DotIgnore.Tests
             var log = new List<string>();
             Assert.IsTrue(list.IsIgnored(file, log));
             Assert.IsTrue(log.Count == 1);
-            Assert.IsTrue(log[0] == "Ignored by test.txt > TEST.TXT > TEST\\.TXT$");
+            Assert.IsTrue(log[0] == "Ignored by test.txt > test.txt");
         }
 
         [Test]
@@ -137,7 +137,7 @@ namespace MAB.DotIgnore.Tests
             var log = new List<string>();
             Assert.IsTrue(list.IsIgnored(directory, log));
             Assert.IsTrue(log.Count == 1);
-            Assert.IsTrue(log[0] == "Ignored by test > TEST > TEST$");
+            Assert.IsTrue(log[0] == "Ignored by test > test");
         }
 
         [TearDown]

--- a/MAB.DotIgnore.Test/IgnoreRuleTests.cs
+++ b/MAB.DotIgnore.Test/IgnoreRuleTests.cs
@@ -38,14 +38,14 @@ namespace MAB.DotIgnore.Tests
         public void ToString_Returns_Correct_Pattern_Info()
         {
             var rule = new IgnoreRule("sub2/**.txt");
-            // Should return original glob pattern > modified glob pattern > translated regex
-            Assert.IsTrue(rule.ToString() == "sub2/**.txt > SUB2/**.TXT > SUB2/.*\\.TXT$");
+            // Should return original glob pattern > modified glob pattern
+            Assert.IsTrue(rule.ToString() == "sub2/**.txt > sub2/**.txt");
         }
 
         [Test]
         public void Case_Sensitive_Match()
         {
-            var rule = new IgnoreRule("test.txt", MatchFlags.PATHNAME);
+            var rule = new IgnoreRule("test.txt");
             Assert.IsTrue(rule.IsMatch("test.txt", true));
             Assert.IsFalse(rule.IsMatch("TEST.TXT", true));
         }
@@ -80,7 +80,7 @@ namespace MAB.DotIgnore.Tests
         public void Match_Relative_No_Wildcards()
         {
             var rule = new IgnoreRule("test.txt");
-            Assert.IsFalse(rule.Negation);
+            Assert.IsFalse(rule.PatternFlags.HasFlag(PatternFlags.NEGATION));
             Assert.IsTrue(rule.IsMatch("/test.txt", false));
             Assert.IsFalse(rule.IsMatch("/test.txt2", false));
             Assert.IsTrue(rule.IsMatch("/sub1/test.txt", false));
@@ -94,7 +94,7 @@ namespace MAB.DotIgnore.Tests
         public void Match_Absolute_No_Wildcards()
         {
             var rule = new IgnoreRule("/test.txt");
-            Assert.IsFalse(rule.Negation);
+            Assert.IsFalse(rule.PatternFlags.HasFlag(PatternFlags.NEGATION));
             Assert.IsTrue(rule.IsMatch("/test.txt", false));
             Assert.IsFalse(rule.IsMatch("/test.txt2", false));
             Assert.IsFalse(rule.IsMatch("/sub1/test.txt", false));
@@ -108,7 +108,7 @@ namespace MAB.DotIgnore.Tests
         public void Match_Directory_Relative_No_Wildcards()
         {
             var rule = new IgnoreRule("test/");
-            Assert.IsFalse(rule.Negation);
+            Assert.IsFalse(rule.PatternFlags.HasFlag(PatternFlags.NEGATION));
             Assert.IsTrue(rule.IsMatch("/test", true));
             Assert.IsFalse(rule.IsMatch("/test2", true));
             Assert.IsTrue(rule.IsMatch("/sub1/test", true));
@@ -121,7 +121,7 @@ namespace MAB.DotIgnore.Tests
         public void Match_Directory_Absolute_No_Wildcards()
         {
             var rule = new IgnoreRule("/test/");
-            Assert.IsFalse(rule.Negation);
+            Assert.IsFalse(rule.PatternFlags.HasFlag(PatternFlags.NEGATION));
             Assert.IsTrue(rule.IsMatch("/test", true));
             Assert.IsFalse(rule.IsMatch("/test2", true));
             Assert.IsFalse(rule.IsMatch("/sub1/test", true));
@@ -134,7 +134,7 @@ namespace MAB.DotIgnore.Tests
         public void Negated_Match_Relative_No_Wildcards()
         {
             var rule = new IgnoreRule("!test.txt");
-            Assert.IsTrue(rule.Negation);
+            Assert.IsTrue(rule.PatternFlags.HasFlag(PatternFlags.NEGATION));
             Assert.IsTrue(rule.IsMatch("/test.txt", false));
             Assert.IsFalse(rule.IsMatch("/test.txt2", false));
             Assert.IsTrue(rule.IsMatch("/sub1/test.txt", false));
@@ -148,7 +148,7 @@ namespace MAB.DotIgnore.Tests
         public void Negated_Match_Absolute_No_Wildcards()
         {
             var rule = new IgnoreRule("!/test.txt");
-            Assert.IsTrue(rule.Negation);
+            Assert.IsTrue(rule.PatternFlags.HasFlag(PatternFlags.NEGATION));
             Assert.IsTrue(rule.IsMatch("/test.txt", false));
             Assert.IsFalse(rule.IsMatch("/test.txt2", false));
             Assert.IsFalse(rule.IsMatch("/sub1/test.txt", false));
@@ -162,7 +162,7 @@ namespace MAB.DotIgnore.Tests
         public void Negated_Match_Directory_Relative_No_Wildcards()
         {
             var rule = new IgnoreRule("!test/");
-            Assert.IsTrue(rule.Negation);
+            Assert.IsTrue(rule.PatternFlags.HasFlag(PatternFlags.NEGATION));
             Assert.IsTrue(rule.IsMatch("/test", true));
             Assert.IsFalse(rule.IsMatch("/test2", true));
             Assert.IsTrue(rule.IsMatch("/sub1/test", true));
@@ -175,7 +175,7 @@ namespace MAB.DotIgnore.Tests
         public void Negated_Match_Directory_Absolute_No_Wildcards()
         {
             var rule = new IgnoreRule("!/test/");
-            Assert.IsTrue(rule.Negation);
+            Assert.IsTrue(rule.PatternFlags.HasFlag(PatternFlags.NEGATION));
             Assert.IsTrue(rule.IsMatch("/test", true));
             Assert.IsFalse(rule.IsMatch("/test2", true));
             Assert.IsFalse(rule.IsMatch("/sub1/test", true));
@@ -188,7 +188,7 @@ namespace MAB.DotIgnore.Tests
         public void Match_Global_Wildcards()
         {
             var rule = new IgnoreRule("*.txt");
-            Assert.IsFalse(rule.Negation);
+            Assert.IsFalse(rule.PatternFlags.HasFlag(PatternFlags.NEGATION));
             Assert.IsTrue(rule.IsMatch("/test.txt", false));
             Assert.IsFalse(rule.IsMatch("/test.txt2", false));
             Assert.IsTrue(rule.IsMatch("/sub1/test.txt", false));
@@ -202,21 +202,7 @@ namespace MAB.DotIgnore.Tests
         public void Negated_Match_Global_Wildcards()
         {
             var rule = new IgnoreRule("!*.txt");
-            Assert.IsTrue(rule.Negation);
-            Assert.IsTrue(rule.IsMatch("/test.txt", false));
-            Assert.IsFalse(rule.IsMatch("/test.txt2", false));
-            Assert.IsTrue(rule.IsMatch("/sub1/test.txt", false));
-            Assert.IsTrue(rule.IsMatch("/sub1/sub2/test.txt", false));
-            // Should match directory as well
-            Assert.IsTrue(rule.IsMatch("/test.txt", true));
-            Assert.IsFalse(rule.IsMatch("/test.txt2", true));
-        }
-
-        [Test]
-        public void Match_Global_Star_Star_Wildcard()
-        {
-            var rule = new IgnoreRule("**.txt");
-            Assert.IsFalse(rule.Negation);
+            Assert.IsTrue(rule.PatternFlags.HasFlag(PatternFlags.NEGATION));
             Assert.IsTrue(rule.IsMatch("/test.txt", false));
             Assert.IsFalse(rule.IsMatch("/test.txt2", false));
             Assert.IsTrue(rule.IsMatch("/sub1/test.txt", false));
@@ -230,7 +216,7 @@ namespace MAB.DotIgnore.Tests
         public void Match_Leading_Star_Star_Wildcard()
         {
             var rule = new IgnoreRule("**/test");
-            Assert.IsFalse(rule.Negation);
+            Assert.IsFalse(rule.PatternFlags.HasFlag(PatternFlags.NEGATION));
             Assert.IsTrue(rule.IsMatch("/test", true));
             Assert.IsFalse(rule.IsMatch("/test2", true));
             Assert.IsTrue(rule.IsMatch("/sub1/test", true));
@@ -240,39 +226,10 @@ namespace MAB.DotIgnore.Tests
         }
 
         [Test]
-        public void Match_Relative_Star_Star_Wildcard()
-        {
-            var rule = new IgnoreRule("sub2/**.txt");
-            Assert.IsFalse(rule.Negation);
-            Assert.IsFalse(rule.IsMatch("/test.txt", false));
-            Assert.IsFalse(rule.IsMatch("/sub1/test.txt", false));
-            Assert.IsTrue(rule.IsMatch("/sub1/sub2/test.txt", false));
-            Assert.IsFalse(rule.IsMatch("/sub1/sub2/test.txt2", false));
-            // Should match directory as well
-            Assert.IsTrue(rule.IsMatch("/sub1/sub2/test.txt", true));
-            Assert.IsFalse(rule.IsMatch("/sub1/sub2/test.txt2", true));
-        }
-
-        [Test]
-        public void Match_Absolute_Star_Star_Wildcard()
-        {
-            var rule = new IgnoreRule("/sub1/**.txt");
-            Assert.IsFalse(rule.Negation);
-            Assert.IsFalse(rule.IsMatch("/test.txt", false));
-            Assert.IsTrue(rule.IsMatch("/sub1/test.txt", false));
-            Assert.IsTrue(rule.IsMatch("/sub1/sub2/test.txt", false));
-            Assert.IsFalse(rule.IsMatch("/sub1/sub2/test.txt2", false));
-            Assert.IsFalse(rule.IsMatch("/sub0/sub1/test.txt", false));
-            // Should match directory as well
-            Assert.IsTrue(rule.IsMatch("/sub1/test.txt", true));
-            Assert.IsFalse(rule.IsMatch("/sub1/test.txt2", true));
-        }
-
-        [Test]
         public void Match_Trailing_Star_Star_Wildcard()
         {
             var rule = new IgnoreRule("sub1/**");
-            Assert.IsFalse(rule.Negation);
+            Assert.IsFalse(rule.PatternFlags.HasFlag(PatternFlags.NEGATION));
             Assert.IsFalse(rule.IsMatch("/test.txt", false));
             Assert.IsTrue(rule.IsMatch("/sub1/test.txt", false));
             Assert.IsTrue(rule.IsMatch("/sub1/sub2/test.txt", false));
@@ -282,27 +239,12 @@ namespace MAB.DotIgnore.Tests
         }
 
         [Test]
-        public void Match_Directory_Global_Star_Star_Wildcard()
-        {
-            var rule = new IgnoreRule("**test/");
-            Assert.IsFalse(rule.Negation);
-            Assert.IsTrue(rule.IsMatch("/test", true));
-            Assert.IsFalse(rule.IsMatch("/test2", true));
-            Assert.IsTrue(rule.IsMatch("/sub1/test", true));
-            Assert.IsFalse(rule.IsMatch("/sub1/test2", true));
-            Assert.IsTrue(rule.IsMatch("/sub1/sub2/test", true));
-            Assert.IsFalse(rule.IsMatch("/sub1/sub2/test2", true));
-            // Should not match file
-            Assert.IsFalse(rule.IsMatch("/test.txt", false));
-        }
-
-        [Test]
         public void Match_Directory_Relative_Star_Star_Wildcard()
         {
             var rule = new IgnoreRule("sub1/**/test/");
-            Assert.IsFalse(rule.Negation);
+            Assert.IsFalse(rule.PatternFlags.HasFlag(PatternFlags.NEGATION));
             Assert.IsFalse(rule.IsMatch("/test", true));
-            Assert.IsFalse(rule.IsMatch("/sub1/test", true));
+            Assert.IsTrue(rule.IsMatch("/sub1/test", true));
             Assert.IsTrue(rule.IsMatch("/sub1/sub2/test", true));
             Assert.IsFalse(rule.IsMatch("/sub1/sub2/test2", true));
             // Should not match file
@@ -310,25 +252,10 @@ namespace MAB.DotIgnore.Tests
         }
 
         [Test]
-        public void Match_Directory_Absolute_Star_Star_Wildcard()
-        {
-            var rule = new IgnoreRule("/sub1/**.txt/");
-            Assert.IsFalse(rule.Negation);
-            Assert.IsFalse(rule.IsMatch("/test.txt", true));
-            Assert.IsTrue(rule.IsMatch("/sub1/test.txt", true));
-            Assert.IsFalse(rule.IsMatch("/sub1/test.txt2", true));
-            Assert.IsTrue(rule.IsMatch("/sub1/sub2/test.txt", true));
-            Assert.IsFalse(rule.IsMatch("/sub1/sub2/test.txt2", true));
-            Assert.IsFalse(rule.IsMatch("/sub0/sub1/test.txt", true));
-            // Should not match file
-            Assert.IsFalse(rule.IsMatch("/sub1/test.txt", false));
-        }
-
-        [Test]
         public void Match_Directory_Trailing_Star_Star_Wildcard()
         {
             var rule = new IgnoreRule("sub1/**/");
-            Assert.IsFalse(rule.Negation);
+            Assert.IsFalse(rule.PatternFlags.HasFlag(PatternFlags.NEGATION));
             Assert.IsFalse(rule.IsMatch("/test.txt", true));
             Assert.IsTrue(rule.IsMatch("/sub1/test.txt", true));
             Assert.IsTrue(rule.IsMatch("/sub1/sub2/test.txt", true));
@@ -338,24 +265,10 @@ namespace MAB.DotIgnore.Tests
         }
 
         [Test]
-        public void Negated_Match_Global_Star_Star_Wildcard()
-        {
-            var rule = new IgnoreRule("!**.txt");
-            Assert.IsTrue(rule.Negation);
-            Assert.IsTrue(rule.IsMatch("/test.txt", false));
-            Assert.IsFalse(rule.IsMatch("/test.txt2", false));
-            Assert.IsTrue(rule.IsMatch("/sub1/test.txt", false));
-            Assert.IsTrue(rule.IsMatch("/sub1/sub2/test.txt", false));
-            // Should match directory as well
-            Assert.IsTrue(rule.IsMatch("/test.txt", true));
-            Assert.IsFalse(rule.IsMatch("/test.txt2", true));
-        }
-
-        [Test]
         public void Negated_Match_Leading_Star_Star_Wildcard()
         {
             var rule = new IgnoreRule("!**/test");
-            Assert.IsTrue(rule.Negation);
+            Assert.IsTrue(rule.PatternFlags.HasFlag(PatternFlags.NEGATION));
             Assert.IsTrue(rule.IsMatch("/test", true));
             Assert.IsFalse(rule.IsMatch("/test2", true));
             Assert.IsTrue(rule.IsMatch("/sub1/test", true));
@@ -366,39 +279,10 @@ namespace MAB.DotIgnore.Tests
         }
 
         [Test]
-        public void Negated_Match_Relative_Star_Star_Wildcard()
-        {
-            var rule = new IgnoreRule("!sub2/**.txt");
-            Assert.IsTrue(rule.Negation);
-            Assert.IsFalse(rule.IsMatch("/test.txt", false));
-            Assert.IsFalse(rule.IsMatch("/sub1/test.txt", false));
-            Assert.IsTrue(rule.IsMatch("/sub1/sub2/test.txt", false));
-            Assert.IsFalse(rule.IsMatch("/sub1/sub2/test.txt2", false));
-            // Should match directory as well
-            Assert.IsTrue(rule.IsMatch("/sub1/sub2/test.txt", true));
-            Assert.IsFalse(rule.IsMatch("/sub1/sub2/test.txt2", true));
-        }
-
-        [Test]
-        public void Negated_Match_Absolute_Star_Star_Wildcard()
-        {
-            var rule = new IgnoreRule("!/sub1/**.txt");
-            Assert.IsTrue(rule.Negation);
-            Assert.IsFalse(rule.IsMatch("/test.txt", false));
-            Assert.IsTrue(rule.IsMatch("/sub1/test.txt", false));
-            Assert.IsFalse(rule.IsMatch("/sub1/test.txt2", false));
-            Assert.IsTrue(rule.IsMatch("/sub1/sub2/test.txt", false));
-            Assert.IsFalse(rule.IsMatch("/sub0/sub1/test.txt", false));
-            // Should match directory as well
-            Assert.IsTrue(rule.IsMatch("/sub1/test.txt", true));
-            Assert.IsFalse(rule.IsMatch("/sub1/test.txt2", true));
-        }
-
-        [Test]
         public void Negated_Match_Trailing_Star_Star_Wildcard()
         {
             var rule = new IgnoreRule("!sub1/**");
-            Assert.IsTrue(rule.Negation);
+            Assert.IsTrue(rule.PatternFlags.HasFlag(PatternFlags.NEGATION));
             Assert.IsFalse(rule.IsMatch("/test.txt", false));
             Assert.IsTrue(rule.IsMatch("/sub1/test.txt", false));
             Assert.IsTrue(rule.IsMatch("/sub1/sub2/test.txt", false));
@@ -411,9 +295,9 @@ namespace MAB.DotIgnore.Tests
         public void Negated_Match_Directory_Relative_Star_Star_Wildcard()
         {
             var rule = new IgnoreRule("!sub1/**/test/");
-            Assert.IsTrue(rule.Negation);
+            Assert.IsTrue(rule.PatternFlags.HasFlag(PatternFlags.NEGATION));
             Assert.IsFalse(rule.IsMatch("/test", true));
-            Assert.IsFalse(rule.IsMatch("/sub1/test", true));
+            Assert.IsTrue(rule.IsMatch("/sub1/test", true));
             Assert.IsTrue(rule.IsMatch("/sub1/sub2/test", true));
             Assert.IsFalse(rule.IsMatch("/sub1/sub2/test2", true));
             // Should not match file
@@ -421,23 +305,10 @@ namespace MAB.DotIgnore.Tests
         }
 
         [Test]
-        public void Negated_Match_Directory_Absolute_Star_Star_Wildcard()
-        {
-            var rule = new IgnoreRule("!/sub1/**.txt/");
-            Assert.IsTrue(rule.Negation);
-            Assert.IsFalse(rule.IsMatch("/test.txt", true));
-            Assert.IsTrue(rule.IsMatch("/sub1/test.txt", true));
-            Assert.IsTrue(rule.IsMatch("/sub1/sub2/test.txt", true));
-            Assert.IsFalse(rule.IsMatch("/sub0/sub1/test.txt", true));
-            // Should not match file
-            Assert.IsFalse(rule.IsMatch("/sub1/test.txt", false));
-        }
-
-        [Test]
         public void Negated_Match_Directory_Trailing_Star_Star_Wildcard()
         {
             var rule = new IgnoreRule("!sub1/**/");
-            Assert.IsTrue(rule.Negation);
+            Assert.IsTrue(rule.PatternFlags.HasFlag(PatternFlags.NEGATION));
             Assert.IsFalse(rule.IsMatch("/test.txt", true));
             Assert.IsTrue(rule.IsMatch("/sub1/test.txt", true));
             Assert.IsTrue(rule.IsMatch("/sub1/sub2/test.txt", true));

--- a/MAB.DotIgnore.Test/MAB.DotIgnore.Test.csproj
+++ b/MAB.DotIgnore.Test/MAB.DotIgnore.Test.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>MAB.DotIgnore.Test</RootNamespace>
     <AssemblyName>MAB.DotIgnore.Test</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/MAB.DotIgnore.Test/MAB.DotIgnore.Test.csproj
+++ b/MAB.DotIgnore.Test/MAB.DotIgnore.Test.csproj
@@ -32,7 +32,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="nunit.framework, Version=3.2.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.3.2.1\lib\net35\nunit.framework.dll</HintPath>
+      <HintPath>..\packages\NUnit.3.2.1\lib\net40\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/MAB.DotIgnore.Test/packages.config
+++ b/MAB.DotIgnore.Test/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit" version="3.2.1" targetFramework="net35" />
+  <package id="NUnit" version="3.2.1" targetFramework="net35" requireReinstallation="true" />
   <package id="NUnit.Console" version="3.2.1" targetFramework="net35" />
   <package id="NUnit.ConsoleRunner" version="3.2.1" targetFramework="net35" />
   <package id="NUnit.Extension.NUnitProjectLoader" version="3.2.1" targetFramework="net35" />

--- a/MAB.DotIgnore.Test/packages.config
+++ b/MAB.DotIgnore.Test/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit" version="3.2.1" targetFramework="net35" requireReinstallation="true" />
+  <package id="NUnit" version="3.2.1" targetFramework="net40" />
   <package id="NUnit.Console" version="3.2.1" targetFramework="net35" />
   <package id="NUnit.ConsoleRunner" version="3.2.1" targetFramework="net35" />
   <package id="NUnit.Extension.NUnitProjectLoader" version="3.2.1" targetFramework="net35" />

--- a/MAB.DotIgnore/IgnoreList.cs
+++ b/MAB.DotIgnore/IgnoreList.cs
@@ -135,11 +135,11 @@ namespace MAB.DotIgnore
             {
                 if (rule.IsMatch(path, pathIsDirectory))
                 {
-                    ignore = !rule.Negation;
+                    ignore = !rule.PatternFlags.HasFlag(PatternFlags.NEGATION);
 
                     if (log != null)
                     {
-                        log.Add(string.Format("{0} by {1}", (rule.Negation ? "Included" : "Ignored"), rule.ToString()));
+                        log.Add(string.Format("{0} by {1}", (rule.PatternFlags.HasFlag(PatternFlags.NEGATION) ? "Included" : "Ignored"), rule.ToString()));
                     }
                 }
             }

--- a/MAB.DotIgnore/IgnoreRule.cs
+++ b/MAB.DotIgnore/IgnoreRule.cs
@@ -91,52 +91,52 @@ namespace MAB.DotIgnore
                 sc = StringComparison.OrdinalIgnoreCase;
         }
 
-        //    PATTERN FORMAT
-        //    
-        //    - A blank line matches no files, so it can serve as a separator for readability.
-        //    
-        //    - A line starting with # serves as a comment. Put a backslash ("\") in front of the first 
-        //      hash for patterns that begin with a hash.
-        //    
-        //    - Trailing spaces are ignored unless they are quoted with backslash("\").
-        //    
-        //    - An optional prefix "!" which negates the pattern; any matching file excluded by a previous 
-        //      pattern will become included again. It is not possible to re-include a file if a parent 
-        //      directory of that file is excluded. Git doesn’t list excluded directories for performance 
-        //      reasons, so any patterns on contained files have no effect, no matter where they are defined.
-        //      Put a backslash("\") in front of the first "!" for patterns that begin with a literal "!", 
-        //      for example: "\!important!.txt".
-        //    
-        //    - If the pattern ends with a slash, it is removed for the purpose of the following description, 
-        //      but it would only find a match with a directory. In other words, foo/ will match a directory 
-        //      foo and paths underneath it, but will not match a regular file or a symbolic link foo (this is 
-        //      consistent with the way how pathspec works in general in Git).
-        //    
-        //    - If the pattern does not contain a slash /, Git treats it as a shell glob pattern and checks 
-        //      for a match against the pathname relative to the location of the.gitignore file (relative to
-        //      the toplevel of the work tree if not from a.gitignore file).
-        //    
-        //    - Otherwise, Git treats the pattern as a shell glob suitable for consumption by fnmatch(3) with 
-        //      the FNM_PATHNAME flag: wildcards in the pattern will not match a / in the pathname.
-        //      For example, "Documentation/*.html" matches "Documentation/git.html" but not 
-        //      "Documentation/ppc/ppc.html" or "tools/perf/Documentation/perf.html".
-        //    
-        //    - A leading slash matches the beginning of the pathname.
-        //      For example, "/*.c" matches "cat-file.c" but not "mozilla-sha1/sha1.c".
-        //    
-        //    Two consecutive asterisks("**") in patterns matched against full pathname may have special meaning:
-        //    
-        //    - A leading "**" followed by a slash means match in all directories.For example, "**/foo" 
-        //      matches file or directory "foo" anywhere, the same as pattern "foo". "**/foo/bar" matches 
-        //      file or directory "bar" anywhere that is directly under directory "foo".
-        //    
-        //    - A trailing "/**" matches everything inside.For example, "abc/**" matches all files inside 
-        //      directory "abc", relative to the location of the.gitignore file, with infinite depth.
-        //    
-        //    - A slash followed by two consecutive asterisks then a slash matches zero or more directories.
-        //      For example, "a/**/b" matches "a/b", "a/x/b", "a/x/y/b" and so on.
-        //    
-        //    - Other consecutive asterisks are considered invalid.
+        // PATTERN FORMAT
+        // 
+        // - A blank line matches no files, so it can serve as a separator for readability.
+        // 
+        // - A line starting with # serves as a comment. Put a backslash ("\") in front of the first 
+        //   hash for patterns that begin with a hash.
+        // 
+        // - Trailing spaces are ignored unless they are quoted with backslash("\").
+        // 
+        // - An optional prefix "!" which negates the pattern; any matching file excluded by a previous 
+        //   pattern will become included again. It is not possible to re-include a file if a parent 
+        //   directory of that file is excluded. Git doesn’t list excluded directories for performance 
+        //   reasons, so any patterns on contained files have no effect, no matter where they are defined.
+        //   Put a backslash("\") in front of the first "!" for patterns that begin with a literal "!", 
+        //   for example: "\!important!.txt".
+        // 
+        // - If the pattern ends with a slash, it is removed for the purpose of the following description, 
+        //   but it would only find a match with a directory. In other words, foo/ will match a directory 
+        //   foo and paths underneath it, but will not match a regular file or a symbolic link foo (this is 
+        //   consistent with the way how pathspec works in general in Git).
+        // 
+        // - If the pattern does not contain a slash /, Git treats it as a shell glob pattern and checks 
+        //   for a match against the pathname relative to the location of the.gitignore file (relative to
+        //   the toplevel of the work tree if not from a.gitignore file).
+        // 
+        // - Otherwise, Git treats the pattern as a shell glob suitable for consumption by fnmatch(3) with 
+        //   the FNM_PATHNAME flag: wildcards in the pattern will not match a / in the pathname.
+        //   For example, "Documentation/*.html" matches "Documentation/git.html" but not 
+        //   "Documentation/ppc/ppc.html" or "tools/perf/Documentation/perf.html".
+        // 
+        // - A leading slash matches the beginning of the pathname.
+        //   For example, "/*.c" matches "cat-file.c" but not "mozilla-sha1/sha1.c".
+        // 
+        // Two consecutive asterisks("**") in patterns matched against full pathname may have special meaning:
+        // 
+        // - A leading "**" followed by a slash means match in all directories.For example, "**/foo" 
+        //   matches file or directory "foo" anywhere, the same as pattern "foo". "**/foo/bar" matches 
+        //   file or directory "bar" anywhere that is directly under directory "foo".
+        // 
+        // - A trailing "/**" matches everything inside.For example, "abc/**" matches all files inside 
+        //   directory "abc", relative to the location of the.gitignore file, with infinite depth.
+        // 
+        // - A slash followed by two consecutive asterisks then a slash matches zero or more directories.
+        //   For example, "a/**/b" matches "a/b", "a/x/b", "a/x/y/b" and so on.
+        // 
+        // - Other consecutive asterisks are considered invalid.
 
         /// <summary>
         /// Check if a file path matches the rule glob pattern

--- a/MAB.DotIgnore/IgnoreRule.cs
+++ b/MAB.DotIgnore/IgnoreRule.cs
@@ -35,7 +35,6 @@ namespace MAB.DotIgnore
         /// Create an individual ignore rule for the specified pattern
         /// </summary>
         /// <param name="pattern">A glob pattern specifying file(s) this rule should ignore</param>
-        /// <param name="matchFlags">Optional MatchFlags which alter the behaviour of the match</param>
         public IgnoreRule(string pattern)
         {
             if(Utils.IsNullOrWhiteSpace(pattern))

--- a/MAB.DotIgnore/MAB.DotIgnore.csproj
+++ b/MAB.DotIgnore/MAB.DotIgnore.csproj
@@ -42,6 +42,7 @@
     <Compile Include="MatchFlags.cs" />
     <Compile Include="PatternFlags.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="WildMatch.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="gulpfile.js" />

--- a/MAB.DotIgnore/MatchFlags.cs
+++ b/MAB.DotIgnore/MatchFlags.cs
@@ -15,7 +15,7 @@ namespace MAB.DotIgnore
         /// <summary>
         /// If set, pattern matches are case-insensitive
         /// </summary>
-        IGNORE_CASE = 1,
+        CASEFOLD = 1,
         /// <summary>
         /// If set, single asterisks in patterns should not match path slashes
         /// </summary>

--- a/MAB.DotIgnore/PatternFlags.cs
+++ b/MAB.DotIgnore/PatternFlags.cs
@@ -9,28 +9,20 @@ namespace MAB.DotIgnore
     public enum PatternFlags 
     {
         /// <summary>
-        /// Pattern is a basic match pattern with no wildcards and no leading/trailing slashes
+        /// Pattern is a basic pattern
         /// </summary>
         NONE = 0,
         /// <summary>
-        /// Pattern contains '*', '[', and/or '?'
+        /// Pattern starts with '!'
         /// </summary>
-        WILD = 1,
-        /// <summary>
-        /// Pattern contains '**'
-        /// </summary>
-        WILD2 = 2,
-        /// <summary>
-        /// Pattern starts with '**'
-        /// </summary>
-        WILD2_PREFIX = 4,
+        NEGATION = 1,
         /// <summary>
         /// Pattern starts with '/'
         /// </summary>
-        ABSOLUTE_PATH = 8,
+        ABSOLUTE_PATH = 2,
         /// <summary>
         /// Pattern should match only directories
         /// </summary>
-        DIRECTORY = 16
+        DIRECTORY = 4
     }
 }

--- a/MAB.DotIgnore/WildMatch.cs
+++ b/MAB.DotIgnore/WildMatch.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace MAB.DotIgnore
 {
-    public static class WildMatch
+    internal static class WildMatch
     {
         public const int ABORT_MALFORMED = 2;
         public const int NOMATCH = 1;
@@ -21,7 +21,7 @@ namespace MAB.DotIgnore
             return Match(pattern.ToCharArray(), text.ToCharArray(), 0, 0, flags);
         }
 
-        public static int Match(char[] pattern, char[] text, int p, int t, MatchFlags flags)
+        private static int Match(char[] pattern, char[] text, int p, int t, MatchFlags flags)
         {
             int p_len = pattern.Length;
             int p_EOP = p_len - 1;

--- a/MAB.DotIgnore/WildMatch.cs
+++ b/MAB.DotIgnore/WildMatch.cs
@@ -1,0 +1,336 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace MAB.DotIgnore
+{
+    public static class WildMatch
+    {
+        public const int ABORT_MALFORMED = 2;
+        public const int NOMATCH = 1;
+        public const int MATCH = 0;
+        public const int ABORT_ALL = -1;
+        public const int ABORT_TO_STARSTAR = -2;
+
+        static char NEGATE_CLASS = '!';
+        static char NEGATE_CLASS2 = '^';
+
+        public static int IsMatch(string pattern, string text, MatchFlags flags)
+        {
+            return Match(pattern.ToCharArray(), text.ToCharArray(), 0, 0, flags);
+        }
+
+        public static int Match(char[] pattern, char[] text, int p, int t, MatchFlags flags)
+        {
+            int p_len = pattern.Length;
+            int p_EOP = p_len - 1;
+
+            int t_len = text.Length;
+            int t_EOP = t_len - 1;
+
+            char p_ch;
+
+            for (; p < p_len && (p_ch = pattern[p]) != -1; p++, t++)
+            {
+                int match, negated;
+                bool match_slash;
+        
+                char t_ch, prev_ch;
+        
+                if (t == t_len && p_ch != '*')
+                    return ABORT_ALL;
+            
+                t_ch = text[t];
+
+                if (flags.HasFlag(MatchFlags.CASEFOLD) && Char.IsUpper(t_ch))
+                    t_ch = Char.ToLower(t_ch);
+                if (flags.HasFlag(MatchFlags.CASEFOLD) && Char.IsUpper(p_ch))
+                    p_ch = Char.ToLower(p_ch);
+
+                switch (p_ch)
+                {
+                    // Escape character: require literal match of next char
+                    case '\\': 
+                        p_ch = pattern[++p];
+                        goto default;
+                    // Normal character: literal match
+                    default: 
+                        if (t_ch != p_ch)
+                            return NOMATCH;
+                        continue;
+                    // Match any character except slash
+                    case '?': 
+                        if (t_ch == '/')
+                            return NOMATCH;
+                        continue;
+                    // Match any character unless PATHNAME flag is set, then match any char except slash
+                    case '*': 
+                        // If the *next* character is a star as well...
+                        if ((++p) < p_len && pattern[p] == '*')
+                        {
+                            // Figure out what the character *before* the first star is
+                            // (using null char to represent the beginning of the pattern)
+                            char pre_star_ch = (p - 2) >= 0 ? pattern[p - 2] : '\0';
+                            // Advance through the pattern until we get to something which *isn't* a star
+                            while ((++p) < p_len && pattern[p] == '*') { }
+                            // If PATHNAME isn't set, a single star also matches slashes
+                            if (!flags.HasFlag(MatchFlags.PATHNAME))
+                            {
+                                match_slash = true;
+                            }
+                            // If the character before the first star is either the beginning of the pattern or a slash,
+                            // and the character after the last star is either the end of the pattern or a slash
+                            else if ((pre_star_ch == '\0' || pre_star_ch == '/') && (p == p_len || pattern[p] == '/'))
+                            {
+                                if ((p == p_len || pattern[p] == '/') && Match(pattern, text, p + 1, t, flags) == MATCH)
+                                    return MATCH;
+
+                                match_slash = true;
+                            }
+                            else
+                            {
+                                // The pattern is invalid (double-star wildcards are only valid 
+                                // if bounded by slashes or beginning/end of line)
+                                return ABORT_MALFORMED;
+                            }
+                        }
+                        else
+                        {
+                            // It's only a single star, so use PATHNAME to determine whether to match slashes
+                            match_slash = !flags.HasFlag(MatchFlags.PATHNAME);
+                        }
+                
+                        // If we're at the end of the pattern
+                        if (p == p_len)
+                        {
+                            // If there was only one star and PATHNAME was set, match_slash will be false
+                            // Trailing "*" matches only if there are no more slash characters
+                            if (!match_slash && Array.IndexOf(text, '/', t) != -1)
+                                return NOMATCH;
+                    
+                            // Trailing "**" matches everything
+                            return MATCH;
+                        }
+                        else if  (!match_slash && pattern[p] == '/') 
+                        {
+                            // We're at a slash, so consume the text until the next slash
+                            int nextSlashIndex = Array.IndexOf(text, '/', t);
+                            // If there aren't any more slashes, this can't be a match
+                            if (nextSlashIndex == -1)
+                                return NOMATCH;
+                        
+                            t = nextSlashIndex;
+                            break;
+                        }
+                
+                        // Try to match the remaining text
+                        // Each time the match fails, remove the first character from the text and retry
+                        while (true)
+                        {
+                            if(t == t_EOP)
+                                break;
+
+                            // Try to advance faster when an asterisk is followed by a literal. 
+                            // We know in this case that the string before the literal must belong to "*".
+                            // If match_slash is false, do not look past the first slash as it cannot belong to '*'.
+                            if (!IsGlobSpecial(pattern[p]))
+                            {
+                                p_ch = pattern[p];
+                        
+                                if (flags.HasFlag(MatchFlags.CASEFOLD) && Char.IsUpper(p_ch))
+                                    p_ch = Char.ToLower(p_ch);
+                            
+                                while (t < t_len && ((t_ch = text[t]) != '/' || match_slash))
+                                {
+                                    if (flags.HasFlag(MatchFlags.CASEFOLD) && Char.IsUpper(t_ch))
+                                        t_ch = Char.ToLower(t_ch);
+                                
+                                    if (t_ch == p_ch)
+                                        break;
+                                
+                                    t++;
+                                }
+                                if (t_ch != p_ch)
+                                    return NOMATCH;
+                            }
+
+                            if ((match = Match(pattern, text, p, t, flags)) != NOMATCH)
+                            {
+                                if(!match_slash || match != ABORT_TO_STARSTAR)
+                                    return match;
+                            }
+                            else if (!match_slash && t_ch == '/')
+                            {
+                                return ABORT_TO_STARSTAR;
+                            }
+                    
+                            t_ch = text[++t];
+                        }
+                
+                        return ABORT_ALL;
+                    // Match character ranges
+                    case '[':
+                        p_ch = pattern[++p];
+                
+                        negated = (p_ch == NEGATE_CLASS || p_ch == NEGATE_CLASS2) ? 1 : 0;
+
+                        if (negated == 1)
+                            p_ch = pattern[++p];
+                
+                        prev_ch = '\0';
+                        match = 0;
+                
+                        do {
+                            if (p == p_len)
+                                return ABORT_ALL;
+                        
+                            if (p_ch == '\\') 
+                            {
+                                if (++p == p_len)
+                                    return ABORT_ALL;
+                        
+                                p_ch = pattern[p];
+                        
+                                if (t_ch == p_ch)
+                                    match = 1;
+                            } 
+                            else if (p_ch == '-' && prev_ch != '\0' && p < p_EOP && pattern[p + 1] != ']') 
+                            {
+                                p_ch = pattern[++p];
+                        
+                                if (p_ch == '\\') 
+                                {
+                                    if (++p == p_len)
+                                        return ABORT_ALL;
+                                
+                                    p_ch = pattern[p];
+                                }
+                                if (t_ch <= p_ch && t_ch >= prev_ch)
+                                {
+                                    match = 1;
+                                }
+                                else if (flags.HasFlag(MatchFlags.CASEFOLD) && Char.IsLower(t_ch)) 
+                                {
+                                    char t_ch_upper = Char.ToUpper(t_ch);
+                                    if (t_ch_upper <= p_ch && t_ch_upper >= prev_ch)
+                                        match = 1;
+                                }
+                                p_ch = '\0'; // This makes "prev_ch" get set to 0
+                            } 
+                            else if (p_ch == '[' && p < p_EOP && pattern[p + 1] == ':') 
+                            {
+                                int s;
+                                int i;
+                        
+                                // SHARED ITERATOR
+                                for (s = p + 2; p < p_len && (p_ch = pattern[p]) != ']'; p++) {} 
+                        
+                                if (p == p_EOP)
+                                    return ABORT_ALL;
+                            
+                                i = p - s - 1;
+                                if (i < 0 || pattern[p - 1] != ':') 
+                                {
+                                    // Didn't find ":]", so treat like a normal set
+                                    p = s - 2;
+                                    p_ch = '[';
+                                    if (t_ch == p_ch)
+                                        match = 1;
+                                    continue;
+                                }
+                                if (CC_EQ(pattern, s, i, "alnum")) 
+                                {
+                                    if (Char.IsLetterOrDigit(t_ch))
+                                        match = 1;
+                                } 
+                                else if (CC_EQ(pattern, s, i, "alpha")) 
+                                {
+                                    if (Char.IsLetter(t_ch))
+                                        match = 1;
+                                } 
+                                else if (CC_EQ(pattern, s, i, "blank")) 
+                                {
+                                    if (Char.IsWhiteSpace(t_ch))
+                                        match = 1;
+                                } 
+                                else if (CC_EQ(pattern, s, i, "cntrl")) 
+                                {
+                                    if (Char.IsControl(t_ch))
+                                        match = 1;
+                                } else if (CC_EQ(pattern, s, i, "digit")) 
+                                {
+                                    if (Char.IsDigit(t_ch))
+                                        match = 1;
+                                } 
+        //				        else if (CC_EQ(pattern, s, i, "graph")) 
+        //				        {
+        //				            if (ISGRAPH(t_ch))
+        //				                match = 1;
+        //				        } 
+                                else if (CC_EQ(pattern, s, i, "lower")) 
+                                {
+                                    if (Char.IsLower(t_ch))
+                                        match = 1;
+                                } 
+        //				        else if (CC_EQ(pattern, s, i, "print")) 
+        //				        {
+        //				            if (ISPRINT(t_ch))
+        //				                match = 1;
+        //				        } 
+                                else if (CC_EQ(pattern, s, i, "punct")) 
+                                {
+                                    if (Char.IsPunctuation(t_ch))
+                                        match = 1;
+                                } 
+                                else if (CC_EQ(pattern, s, i, "space")) 
+                                {
+                                    if (Char.IsWhiteSpace(t_ch))
+                                        match = 1;
+                                } 
+                                else if (CC_EQ(pattern, s, i, "upper")) 
+                                {
+                                    if (Char.IsUpper(t_ch))
+                                        match = 1;
+                                    else if (flags.HasFlag(MatchFlags.CASEFOLD) && Char.IsLower(t_ch))
+                                        match = 1;
+                                }
+                                else if (CC_EQ(pattern, s, i, "xdigit")) 
+                                {
+                                    if (Char.IsSurrogate(t_ch))
+                                        match = 1;
+                                } 
+                                else // Malformed [:class:] string
+                                {
+                                    return ABORT_ALL;
+                                }
+                                p_ch = '\0'; // This makes "prev_ch" get set to 0
+                            } 
+                            else if (t_ch == p_ch)
+                            {
+                                match = 1;
+                            }
+                            prev_ch = p_ch;
+                        } while (p < p_len && (p_ch = pattern[++p]) != ']');
+                
+                        if (match == negated || (flags.HasFlag(MatchFlags.PATHNAME) && t_ch == '/'))
+                            return NOMATCH;
+                
+                        continue;
+                }
+            }
+    
+            return t == text.Length ? MATCH : NOMATCH;
+        }
+
+        static bool IsGlobSpecial(char c)
+        {
+            return c == '*' || c == '?' || c == '[' || c == '\\';
+        }
+
+        static bool CC_EQ(char[] pattern, int s, int len, string @class)
+        {
+            return new String(pattern, s, len).CompareTo(@class) == 0;
+        }
+    }
+}

--- a/MAB.DotIgnore/WildMatch.cs
+++ b/MAB.DotIgnore/WildMatch.cs
@@ -330,7 +330,7 @@ namespace MAB.DotIgnore
 
         static bool CC_EQ(char[] pattern, int s, int len, string @class)
         {
-            return new String(pattern, s, len).CompareTo(@class) == 0;
+            return string.Compare(new String(pattern, s, len), @class, StringComparison.Ordinal) == 0;
         }
     }
 }


### PR DESCRIPTION
Rewrite the matching engine to use an implementation of the `wildmatch` function used by Git ([reference source](https://github.com/git/git/blob/master/wildmatch.c)).