### PR TITLE
Trim segment that is null or white space.

### DIFF
--- a/MAB.DotIgnore/IgnoreList.cs
+++ b/MAB.DotIgnore/IgnoreList.cs
@@ -187,7 +187,7 @@ namespace MAB.DotIgnore
 
         private bool IsAnyParentDirectoryIgnored(string path, IgnoreLog log)
         {
-            var segments = path.NormalisePath().Split('/').ToList();
+            var segments = path.NormalisePath().Split('/').Where(s => !string.IsNullOrWhiteSpace(s)).ToList();
 
             segments.RemoveAt(segments.Count - 1);
 


### PR DESCRIPTION
This fixes the following scenario:

```csharp
        [Test]
        public void Meh()
        {
            var ignoreList = new IgnoreList("/Temp/.gitignore");
            var r = ignoreList.IsIgnored("/Temp/B.fs", false);
        }
```

When `/Temp/B.fs` is passed into `IsAnyParentDirectoryIgnored` segments now will contain `"", "Temp", "B.fs"`.
On Windows this could not be a problem as the path would contains the drive letter.
On Linux however, this is a problem as `IsPathIgnored` will throw an argument exception for the incoming `path` argument.

Sorry for not including a proper test, I'm not sure how to proceed in this case.